### PR TITLE
Modernize self-help instructions, update tested hardware lists.

### DIFF
--- a/mtx/FAQ
+++ b/mtx/FAQ
@@ -1,6 +1,6 @@
 Frequently Asked Questions List, v 1.0.1
 
-Index: 
+Index:
   I. Compiling
   II. Finding the correct device
   III. Operational Issues
@@ -9,68 +9,70 @@ Part I: Compiling.
 
 Q: Where is the Makefile in the tarball?
 A: MTX now uses GNU Autoconf to generate the Makefile. Type "./configure"
-   while in the extracted mtx directory. 
+   while in the extracted mtx directory.
 
 Q: Typing 'make' gives me a bunch of errors in the Makefile. Why can't
    you provide a Makefile that works?
-A: Note that you need the GNU 'make'. The BSD 'make' won't work, and 
+A: Note that you need the GNU 'make'. The BSD 'make' won't work, and
   Solaris 'make' probably won't work either. If you want a better
   configuration and makefile system, write one, then EMAIL me the results --
-  mtx is Open Source software and needs your code contributions to grow. 
+  mtx is Open Source software and needs your code contributions to grow.
 
 Q: How do I compile for operating systems other than Linux?
 A: MTX no longer needs you to edit the Makefile to compile for operating
-   systems other than Linux. Just type ./configure and go with it. 
+   systems other than Linux. Just type ./configure and go with it.
 
 Q: How do I port it to OS's other than the supported ones?
 A: Create a new scsi_ module using one of the existing modules as an
    example (scsi_freebsd.c might be a good model). Decide what symbol
    you want #ifdef'ed in order to include that scsi_ module. Edit
    mtxl.c to #include your scsi_ module. Edit the Makefile to add the
-   new target, including the -D needed to #include your new scsi_ module. 
+   new target, including the -D needed to #include your new scsi_ module.
 
 *********************************************************************
-Part II: Finding the correct device. 
+Part II: Finding the correct device.
 
 Q: Why does this command not work??
     [root@Scotty mtxl-1.4.8]# ./mtx -f /dev/st0 inquiry
    In /var/log/messages I see:
-      st0: Write not multiple of tape block size. 
+      st0: Write not multiple of tape block size.
 A: Note that mtx 1.2 and above use the SCSI GENERIC interface on Linux,
   FreeBSD, and Solaris (at least). They do NOT use the tape device node.
 
-Q: When I do 'mtx -f /dev/sga inquiry' it shows 
+Q: When I do 'mtx -f /dev/sga inquiry' it shows
       Product Type: Tape Drive
-      Vendor Id: HP       
-      Product ID: C1553A 
+      Vendor Id: HP
+      Product ID: C1553A
    But when I do a 'mtx -f /dev/sga status' it fails. Why?!
 A: You're trying to send a robotics command to a tape drive. You need
    to send robotics commands to robotics devices, not to tape drives. Look in
-  /proc/scsi/scsi (Linux) or camcontrol (FreeBSD) to find out what the
+  lsscsi -gc (Linux) or camcontrol (FreeBSD) to find out what the
   robotics device is. It will be reported as a 'Medium Changer', not a
   'Sequential Access' or 'Tape Drive'.
 
 Q: When I do 'cat /proc/scsi/scsi' it shows only one device, the tape device!
 A: You are using a DAT autochanger that has one SCSI ID but two LUN's, LUN 0
    and LUN 1. You need to compile a new kernel with  SCAN SCSI LUNS enabled
-   or add this line to your /etc/lilo.conf (then run /sbin/lilo and reboot): 
+   or add this line to your /etc/lilo.conf (then run /sbin/lilo and reboot):
        append="max_scsi_luns=2"
 
-Q: I'm tired of typing '-f /dev/sgc' all the time. How do I set a default
+Q: I'm tired of typing '-f /dev/sg2' all the time. How do I set a default
   device that 'mtx' looks at?
 A: Set the CHANGER environment variable. For example, with 'bash':
-     export CHANGER=/dev/sgc
+     export CHANGER=/dev/sg2
 
 Q: I get "modprobe: can't locate module char-major-21"
    syslog messages being squirreled away into a file on our syslog host,
    and mtx doesn't work. What's the problem?
 A: You need to compile SCSI generic support into your kernel (or as a module).
 
-Q: When I installed mtx, a message showed 
+Q: When I installed mtx, a message showed
    up on the console stating that a scsi changer was found at
    dev sgr. However, I have no device /dev/sgr.
-A: On Linux, do 'mknod /dev/sgr c 21 19' to create a device node. By default
-  only 16 SCSI generic nodes are created, which might not be enough if
+A: On Linux, device nodes should be created automatically by udev.
+  If you're not using udev, you could try 'mknod /dev/sgr c 21 19'
+  to create a device node. By default (if you're not using udev)
+  only 16 SCSI generic nodes are created.  That might not be enough if
   you have multiple SCSI controllers with lots of devices.
 
 ******************************************************
@@ -86,7 +88,7 @@ Q: I'm using Red Hat 7.0 and mtx works fine when I type ./mtx from the
 A: Do "rpm -e mtx". Red Hat 7.0 includes a busted version of mtx. Your
    script is apparently picking up the busted mtx in your path. Get rid
    of the busted mtx, make sure that /usr/local/bin (or wherever you
-   put the "good" mtx) is in the path, and all should be well. 
+   put the "good" mtx) is in the path, and all should be well.
 
 Q: I get
    # /usr/local/bin/mtx -f /dev/sgr status
@@ -98,47 +100,46 @@ Q: I get
   What gives?
 A: Make sure your loader is in random mode, not sequential mode.
    Most "real" loaders (as vs. DAT autoloaders) will not properly report
-   status information unless they are in "random" mode. 
-
+   status information unless they are in "random" mode.
 
 Q: I issue 'mtx load 5' and it loads tape 5. But when I try to put the tape
    back in the magazine, we hit problems:
       mtx: MOVE MEDIUM from Element Address 82 to 5 Failed
    What gives?
 A: Many loaders require you to first eject the tape (using 'mt' or 'tapectl')
-  before you issue an 'unload' command via 'mtx'. 
+  before you issue an 'unload' command via 'mtx'.
 
 Q: My Breece Hill loader does not properly report its slots.
-A: Either set the "auto-inventory" feature in the loader's control panel, 
-   or run 'mtx inventory' prior to running 'mtx status'. 
+A: Either set the "auto-inventory" feature in the loader's control panel,
+   or run 'mtx inventory' prior to running 'mtx status'.
 
 Q: My Breece Hill loader takes a long time to do an inventory. mtx times
    out and spits all over the place. Help!
 A: Many loaders that support barcodes will perform poorly if you place tapes
   into them without bar codes. Place bar codes on all your tapes and you
-  should be able to run 'mtx inventory' without that failure.
+  should be able to run 'mtx inventory' without that failure.  You can
+  print your own bar codes (e.g. using http://tapelabel.de/).
 
 Q: How do I eject the magazine of my autoloader?
-A: Many low-end DAT autoloaders support the removable media 'EJECT' command 
+A: Many low-end DAT autoloaders support the removable media 'EJECT' command
    sent to the robotics device, even though it's not documented (or required)
-   in the SCSI standards. If the loader is at /dev/sgb, simply do 
-   'mtx -f /dev/sgb eject' and see what happens. (If nothing happens, 
-    your autoloader doesn't support 'eject'). Some high-end libraries have 
-   their own proprietary way for ejecting magazine trays, generally 
+   in the SCSI standards. If the loader is at /dev/sg1, simply do
+   'mtx -f /dev/sg1 eject' and see what happens. (If nothing happens,
+    your autoloader doesn't support 'eject'). Some high-end libraries have
+   their own proprietary way for ejecting magazine trays, generally
    involving abuse of the 'transfer' command and 'eepos' addendums,
-    but this is totally non-standard and undocumented. 
+    but this is totally non-standard and undocumented.
 
 Q: Is there a standard for cleaning tape bar codes?
-A: Many libraries, and many backup programs, expect cleaning tape bar 
-   codes to start with "CLN". 
+A: Many libraries, and many backup programs, expect cleaning tape bar
+   codes to start with "CLN".
 
 Q: How do I report a bug?
 A: First, read this FAQ. Next, check the mtx list archives at
-   http://mtx.sourceforge.net to make sure that it's not already addressed 
-   by somebody else. If your problem is still not solved, send 
+   http://mtx.sourceforge.net to make sure that it's not already addressed
+   by somebody else. If your problem is still not solved, send
    (to the mtx list) the following information:
-        Result of 'mtx inquiry' on the loader, 
+        Result of 'mtx inquiry' on the loader,
         Result of 'mtx status' on the loader (minus a bunch of tapes if
-          it's a 50+ tape loader!), 
-        Results of the operation that isn't working correctly. 
-
+          it's a 50+ tape loader!),
+        Results of the operation that isn't working correctly.

--- a/mtx/loaderinfo.1
+++ b/mtx/loaderinfo.1
@@ -27,63 +27,65 @@ loaderinfo \- report SCSI tape device info
 .SH SYNOPSIS
 loaderinfo -f <scsi-generic-device>
 .SH DESCRIPTION
-The 
+The
 .B loaderinfo
 command reads various information from SCSI tape loaders. Its intended
 use is for high-level programs that are trying to decide what the
-capabilities of a device are. 
+capabilities of a device are.
 .P
 The following are printed:
 .TP 10
 .B  Element Address Assignment Page:
 This tells how many elements are in the loader, and what their raw
-hardware addresses are. 
+hardware addresses are.
 
 .TP 10
 .B Transport Geometry Descriptor Page:
 Will display whether media is invertible or not (usable with some
 optical jukeboxes for detirmining whether to "flip" media after writing
-to the first side). 
+to the first side).
 
-.TP 10 
+.TP 10
 .B Device Capabilities Page
 Currently will only display whether we can transfer between slots (i.e.
-whether 'mtx transfer' works). 
+whether 'mtx transfer' works).
 
 .TP 10
 .B Inquiry Page
 Aside from the normal inquiry info, will also print out whether we have
 a bar code reader (for loaders that support the Exabyte extension for
-reporting presense of said reader). 
+reporting presense of said reader).
 
 
 .SH OPTIONS
 The first argument, given following
 .B -f
-, is the SCSI generic device corresponding to your tape loader. 
+, is the SCSI generic device corresponding to your tape loader.
 Consult your operating system's documentation for more information (for
-example, under Linux these are generally start at /dev/sg0 
+example, under Linux these are generally start at /dev/sg0
 under FreeBSD these start at /dev/pass0).
 .P
 Under FreeBSD, 'camcontrol devlist' will tell you what SCSI devices you
 have, along with which 'pass' device controls them. Under Linux,
-"cat /proc/scsi/scsi" will tell you what SCSI devices you have. Under
-Solaris 8, 
+the command
+.B lsscsi \-\-generic
+will tell you what SCSI devices you have.
+Under Solaris 8,
 .B find /devices -name '*changer*'
 will display the device names for your attached changers. Make sure
-to configure your 'sgen' driver first. 
+to configure your 'sgen' driver first.
 
 .SH BUGS AND LIMITATIONS
 .P
 This program has only been tested on Linux with a limited number of
-loaders (Ecrix Autopack, Exabyte 220). 
+loaders (Ecrix Autopack, Exabyte 220, IBM TS3100).
 .P
 .SH AVAILABILITY
 .B loaderinfo
-is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net> 
-as part of the 'mtx' suite of programs. The 'mtx' home page is 
-http://mtx.sourceforge.net and the actual code is currently available there and via 
-SVN from http://sourceforge.net/projects/mtx. 
+is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net>
+as part of the 'mtx' suite of programs. The 'mtx' home page is
+http://mtx.sourceforge.net and the actual code is currently available there and via
+SVN from http://sourceforge.net/projects/mtx.
 
 .SH SEE ALSO
 .BR mt (1), tapeinfo (1), mtx (1)

--- a/mtx/mtx.1
+++ b/mtx/mtx.1
@@ -24,35 +24,35 @@
 .\"
 .TH MTX 1 MTX1.3
 .SH NAME
-mtx \- control SCSI media changer devices 
+mtx \- control SCSI media changer devices
 .SH SYNOPSIS
 mtx [-f <scsi-generic-device>] [nobarcode] [invert] [noattach] command [ command ... ]
 .SH DESCRIPTION
-The 
+The
 .B mtx
 command controls single or multi-drive SCSI media changers such as
 tape changers, autoloaders, tape libraries, or optical media jukeboxes.
-It can also be used with media changers that use the 'ATTACHED' API, 
+It can also be used with media changers that use the 'ATTACHED' API,
 presuming that they properly report the MChanger bit as required
-by the SCSI T-10 SMC specification. 
+by the SCSI T-10 SMC specification.
 .SH OPTIONS
 The first argument, given following
 .B -f
-, is the SCSI generic device corresponding to your media changer. 
+, is the SCSI generic device corresponding to your media changer.
 Consult your operating system's documentation for more information (for
-example, under Linux these are generally /dev/sg0 through /dev/sg15, 
+example, under Linux these are generally /dev/sg0 through /dev/sgXX.
 under FreeBSD these are /dev/pass0 through /dev/passX,
-under SunOS it may be a file under /dev/rdsk).  
+under SunOS it may be a file under /dev/rdsk).
 .P
 The 'invert' option will invert (flip) the media (for optical jukeboxes that
 allow such) before inserting it into the drive or returning it to the
-storage slot. 
+storage slot.
 .P
 The 'noattach' option forces the regular media changer API even if the
-media changer incorrectly reported that it uses the 'ATTACHED' API. 
+media changer incorrectly reported that it uses the 'ATTACHED' API.
 .P
 The 'nobarcode' option forces the loader to not request barcodes even if
-the loader is capable of reporting them.  
+the loader is capable of reporting them.
 .P
 Following these options there may follow
 one or more robotics control
@@ -63,25 +63,25 @@ commands.
 .SH COMMANDS
 .TP 10
 .B --version
-Report the mtx version number (e.g. mtx 1.2.8) and exit. 
+Report the mtx version number (e.g. mtx 1.2.8) and exit.
 
 .TP 10
 .B inquiry
 Report the product type (Medium Changer, Tape Drive, etc.), Vendor ID,
 Product ID, Revision, and whether this uses the Attached Changer API
 (some tape drives use this rather than reporting a Medium Changer on a
-separate LUN or SCSI address). 
+separate LUN or SCSI address).
 .TP 10
 .B noattach
-Make further commands use the regular media changer API rather than the 
+Make further commands use the regular media changer API rather than the
 _ATTACHED API, no matter what the "Attached" bit said in the Inquiry info.
 Needed with some brain-dead changers that report Attached bit but don't respond
-to _ATTACHED API. 
+to _ATTACHED API.
 .TP 10
 .B inventory
 Makes the robot arm go and check what elements are in the slots. This
-is needed for a few libraries like the Breece Hill ones that do not 
-automatically check the tape inventory at system startup. 
+is needed for a few libraries like the Breece Hill ones that do not
+automatically check the tape inventory at system startup.
 .TP 10
 .B status
 Reports how many drives and storage elements are contained in the
@@ -92,7 +92,7 @@ has a bar code, MIC reader, or some other way of uniquely identifying
 media without loading it into a drive, this reports the volume tag
 and/or alternate volume tag for each piece of media.
 For historical reasons drives are numbered from 0 and storage slots are
-numbered from 1. 
+numbered from 1.
 .TP 10
 .B load <slotnum> [ <drivenum> ]
 Load media from slot <slotnum> into drive <drivenum>. Drive 0 is assumed
@@ -103,24 +103,24 @@ Unloads media from drive <drivenum> into slot <slotnum>. If <drivenum> is
 omitted, defaults to drive 0 (as do all commands).
 If <slotnum> is omitted, defaults to the slot
 that the drive was loaded from. Note that there's currently no way to
-say 'unload drive 1's media to the slot it came from', other than to 
+say 'unload drive 1's media to the slot it came from', other than to
 explicitly use that slot number as the destination.
 .TP 10
 .B [eepos <operation>] transfer <slotnum> <slotnum>
 Transfers media from one slot to another, assuming that your mechanism is
 capable of doing so. Usually used to move media to/from an import/export
-port. 'eepos' is used to extend/retract the import/export 
+port. 'eepos' is used to extend/retract the import/export
 tray on certain mid-range to high end tape libraries (if, e.g., the tray was
-slot 32, you might say say 'eepos 1 transfer 32 32' to extend the tray). 
+slot 32, you might say say 'eepos 1 transfer 32 32' to extend the tray).
 Valid values for eepos <operation>
 are 0 (do nothing to the import/export tray), 1, and 2 (what 1 and 2 do varies
-depending upon the library, consult your library's SCSI-level 
-documentation). 
+depending upon the library, consult your library's SCSI-level
+documentation).
 .TP 10
 .B [eepos <operation>] [invert] [invert2] exchange <slotnum> <slotnum> [<slotnum>]
 Move medium from the first slot to the second slot, placing the medium
 currently in the second slot either back into the first slot or into the
-optional third slot. 
+optional third slot.
 
 .TP 10
 .B first  [<drivenum>]
@@ -135,7 +135,7 @@ cleaning tape. If <drivenum> is omitted, defaults to first drive.
 .B last [<drivenum>]
 Loads drive <drivenum> from the last slot in the media changer. Unloads
 the drive if there is already a tape in it. (Note: you may need to eject
-the tape using your OS's tape control commands first).  
+the tape using your OS's tape control commands first).
 .TP 10
 .B next [<drivenum>]
 Unloads the drive and loads the next tape in sequence. If the drive was
@@ -147,18 +147,19 @@ move to and open the import/export, or mailbox, slot.
 
 .SH AUTHORS
 The original 'mtx' program was written by Leonard Zubkoff and extensively
-revised for large multi-drive libraries with bar code readers 
-by Eric Lee Green <eric@badtux.org>. See 'mtx.c' for other contributors. 
+revised for large multi-drive libraries with bar code readers
+by Eric Lee Green <eric@badtux.org>. See 'mtx.c' for other contributors.
 .SH BUGS AND LIMITATIONS
 .P
 You may need to do a 'mt offline' on the tape drive to eject the tape
 before you can issue the 'mtx unload' command. The Exabyte EZ-17 and 220
 in particular will happily sit there snapping the robot arm's claws around
-thin air trying to grab a tape that's not there. 
+thin air trying to grab a tape that's not there.
 .P
 For some Linux distributions, you may need to re-compile the kernel to
-scan SCSI LUN's in order to detect the media changer. Check /proc/scsi/scsi
-to see what's going on. 
+scan SCSI LUN's in order to detect the media changer. Check
+.B lsscsi \-c
+to see what's going on.
 .P
 If you try to unload a tape to its 'source' slot, and said slot is
 full, it will instead put the tape into the first empty
@@ -180,45 +181,40 @@ may fail this request due to inability to find contiguous pages of
 memory for the SCSI transfer (later versions of Linux 'sg' device do
 scatter-gather so that this should no longer be a problem).
 .P
-The 
+The
 .B eepos
 command remains in effect for all further commands on a command
-line. Thus you might want to follow 
+line. Thus you might want to follow
 .B eepos 1 transfer 32 32
-with 
+with
 .B eepos 0
 as
-the next command (which clears the 
+the next command (which clears the
 .B eepos
-bits). 
+bits).
 .P
 Need a better name for 'eepos' command! ('eepos' is the name of the bit
 field in the actual low-level SCSI command, and has nothing to do with what
-it does). 
+it does).
 .P
 
 This program has only been tested on Linux with a limited number of
-tape loaders (a dual-drive Exabyte 220 tape library, with bar-code
+tape loaders (an IBM TS3100 with bar-code reader and 24 slots,
+a dual-drive Exabyte 220 tape library, with bar-code
 reader and 21 slots, an Exabyte EZ-17 7-slot autoloader, and a Seagate
-DDS-4 autochanger with 6 slots). It may not work on other operating systems 
-with larger libraries,
-due to the big SCSI request size. 
-Please see the projecdt page http://sourceforge.net/projects/mtx for information 
+DDS-4 autochanger with 6 slots). It may not work on other operating systems
+with larger libraries, due to the big SCSI request size.
+Please see the project page http://sourceforge.net/projects/mtx for information
 on reporting bugs, requesting features and the mailing list for peer support.
 .SH HINTS
-Under Linux, 
-.B cat /proc/scsi/scsi
-will tell you what SCSI devices you have.
-You can then refer to them as 
-.B /dev/sga,
-.B /dev/sgb, 
-etc. by the order they
-are reported.
+Under Linux,
+.B lsscsi \-g
+will tell you what SCSI devices you have and their device names.
 .P
-Under FreeBSD, 
+Under FreeBSD,
 .B camcontrol devlist
 will tell you what SCSI devices you
-have, along with which 
+have, along with which
 .B pass
 device controls them.
 .P
@@ -229,28 +225,28 @@ then reboot. You can find your changer in /devices by typing
 .B /usr/sbin/devfsadm -C
 to clean out no-longer-extant entries in your /devices directory, then
 .B find /devices -name \*changer -print
-to find the device name. Set the symbolic link 
-.B /dev/changer 
+to find the device name. Set the symbolic link
+.B /dev/changer
 to point
 to that device name (if it is not doing so already).
 .P
 With BRU, set your mount and unmount commands as described on the BRU
 web site at http://www.bru.com to move to the next tape when backing up
-or restoring. With GNU 
+or restoring. With GNU
 .B tar,
-see 
+see
 .B mtx.doc
 for an example of how to use
 .B tar
-and 
+and
 .B mtx
-to make multi-tape backups. 
+to make multi-tape backups.
 
 .SH AVAILABILITY
-This version of 
+This version of
 .B mtx
 is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net> .
 The 'mtx' home page is http://mtx.sourceforge.net and the actual code is currently available
-there and via SVN from http://sourceforge.net/projects/mtx. 
+there and via SVN from http://sourceforge.net/projects/mtx.
 .SH SEE ALSO
 .BR mt (1), loaderinfo (1), tapeinfo (1), scsitape (1), scsieject (1)

--- a/mtx/scsieject.1
+++ b/mtx/scsieject.1
@@ -22,20 +22,20 @@
 .\"
 .TH scsieject 1 scsieject1.0
 .SH NAME
-scsieject \- control SCSI tape devices 
+scsieject \- control SCSI tape devices
 .SH SYNOPSIS
 scsieject [-f <scsi-generic-device>] commands
 .SH DESCRIPTION
-The 
+The
 .B scsieject
 command controls SCSI devices in a platform-independent
-manner. As long as 'mtx' works on the platform, so does 'scsieject'. 
+manner. As long as 'mtx' works on the platform, so does 'scsieject'.
 .SH OPTIONS
 The first argument, given following
 .B -f
 , is the SCSI generic device corresponding to your tape drive.
 Consult your operating system's documentation for more information (for
-example, under Linux these are generally /dev/sg0 through /dev/sg15, 
+example, under Linux these are generally /dev/sg0 through /dev/sgXX,
 under FreeBSD these are /dev/pass0 through /dev/passX. Under Solaris
 this is usually the same as your tape drive (Solaris has a SCSI passthrough
 ioctl). You can set the STAPE or TAPE environment variable rather
@@ -44,22 +44,22 @@ than use -f.
 .SH COMMANDS
 .TP 10
 .B load
-Load the medium into the drive.  When this command is issued to a CD/DVD drive 
+Load the medium into the drive.  When this command is issued to a CD/DVD drive
 and the tray is extended the tray will be retracted if the drive is capable of it.
 
 .TP 10
 .B unload
-Unload the medium from the drive (also known as eject).  When this command is issued 
+Unload the medium from the drive (also known as eject).  When this command is issued
 to a CD/DVD drive or a tape drive the media will be ejected if the device supports it.
 
 .TP 10
 .B start
-Start the device.  Some devices require a start command after a media changer has 
+Start the device.  Some devices require a start command after a media changer has
 loaded new media into the device.
 
 .TP 10
 .B stop
-Stop the device.  Some devices require a stop command prior to unloading the medium 
+Stop the device.  Some devices require a stop command prior to unloading the medium
 from the device when using a media changer.
 
 .TP 10
@@ -71,46 +71,41 @@ Lock the device.  Locks the device so that the medium cannot be removed manually
 Unlock the device.  Unlocks the device so that the medium can be removed manually.
 
 .SH AUTHORS
-This program was written by Robert Nelson <robertnelson@users.sourceforge.net> 
-based on the scsitape program written by Eric Lee Green <eric@badtux.org>. 
+This program was written by Robert Nelson <robertnelson@users.sourceforge.net>
+based on the scsitape program written by Eric Lee Green <eric@badtux.org>.
 Major portions of the 'mtxl.c' library used herein were written by
-Leonard Zubkoff. 
+Leonard Zubkoff.
 .P
 
 .SH HINTS
-Under Linux, 
-.B cat /proc/scsi/scsi
-will tell you what SCSI devices you have.
-You can then refer to them as 
-.B /dev/sga,
-.B /dev/sgb, 
-etc. by the order they
-are reported.
+Under Linux,
+.B lsscsi \-\-generic
+will tell you what SCSI devices you have and their device names.
 .P
-Under FreeBSD, 
+Under FreeBSD,
 .B camcontrol devlist
 will tell you what SCSI devices you
-have, along with which 
+have, along with which
 .B pass
 device controls them.
 .P
 Under Solaris 7 and 8,
 .B /usr/sbin/devfsadm -C
 will clean up your /devices directory. Then
-.B find /devices -name 'st@*' -print 
+.B find /devices -name 'st@*' -print
 will return a list of all tape drives. /dev on Solaris is apparently only
-of historical interest. 
+of historical interest.
 
 .SH BUGS AND LIMITATIONS
 There are no known bugs or limitations.
 
 .SH AVAILABILITY
-This version of 
+This version of
 .B scsieject
-is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net> 
-as part of the 'mtx' suite of programs. The 'mtx' home page is 
-http://mtx.sourceforge.net and the actual code is currently available there and via 
-SVN from http://sourceforge.net/projects/mtx. 
+is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net>
+as part of the 'mtx' suite of programs. The 'mtx' home page is
+http://mtx.sourceforge.net and the actual code is currently available there and via
+SVN from http://sourceforge.net/projects/mtx.
 
 .SH SEE ALSO
 .BR loaderinfo (1), tapeinfo (1), mtx (1)

--- a/mtx/scsitape.1
+++ b/mtx/scsitape.1
@@ -22,14 +22,14 @@
 .\"
 .TH SCSITAPE 1 SCSITAPE1.0
 .SH NAME
-scsitape \- control SCSI tape devices 
+scsitape \- control SCSI tape devices
 .SH SYNOPSIS
 scsitape [-f <scsi-generic-device>] commands
 .SH DESCRIPTION
-The 
+The
 .B scsitape
 command controls SCSI tape drives in a platform-independent
-manner. As long as 'mtx' works on the platform, so does 'scsitape'. 
+manner. As long as 'mtx' works on the platform, so does 'scsitape'.
 .P
 Note that 'scsitape' and your OS's native tape driver may stomp on each
 other. In particular, if you use 'setblk' and your OS's native tape
@@ -37,13 +37,13 @@ driver has a different notion of the block size, you may get evil results.
 It is recommended to use 'scsitape' only for software where you've written
 your own low-level READ and WRITE routines that use the SCSI command set
 to directly talk to tape drives (i.e., you do not use the OS's native tape
-driver at all). 
+driver at all).
 .SH OPTIONS
 The first argument, given following
 .B -f
 , is the SCSI generic device corresponding to your tape drive.
 Consult your operating system's documentation for more information (for
-example, under Linux these are generally /dev/sg0 through /dev/sg15, 
+example, under Linux these are generally /dev/sg0 through /dev/sg15,
 under FreeBSD these are /dev/pass0 through /dev/passX. Under Solaris
 this is usually the same as your tape drive (Solaris has a SCSI passthrough
 ioctl). You can set the STAPE or TAPE environment variable rather
@@ -53,7 +53,7 @@ than use -f.
 .TP 10
 .B setblk <n>
 Set the tape drive's SCSI block size to <n> bytes. (NOTE: if you are
-using your OS's native tape driver, THIS IS EVIL!). 
+using your OS's native tape driver, THIS IS EVIL!).
 
 .TP 10
 .B fsf <n>
@@ -66,7 +66,7 @@ after a tapemark and type 'bfs 1', it moves to immediately *before*
 that tape mark, for a sum total of zero effective movement!).
 .TP 10
 .B eod
-Go to end of data. 
+Go to end of data.
 .TP 10
 .B rewind
 Rewind the tape drive.
@@ -75,21 +75,21 @@ Rewind the tape drive.
 Eject the tape currently in the drive.
 .TP 10
 .B erase
-Does a *short* erase (warning: does NOT work on all drives!). 
+Does a *short* erase (warning: does NOT work on all drives!).
 .TP 10
 .B mark <n>
- write <n> filemarks ( 'mark 0' flushes the drive's buffers ). 
+ write <n> filemarks ( 'mark 0' flushes the drive's buffers ).
 .TP 10
 .B seek <n>
 Seek to a logical position <n> that was reported by a previous 'tapeinfo'
-command. 
+command.
 .TP 10
-.B write <blocksize> 
+.B write <blocksize>
 write blocks from stdin to the tape. Chunk the data into <blocksize>-sized
-chunks. *DOES NOT WRITE OUT A TAPEMARK!* (you will need to use a 
+chunks. *DOES NOT WRITE OUT A TAPEMARK!* (you will need to use a
 subsequent
 .B mark 1
-command to write out a tape mark). 
+command to write out a tape mark).
 .TP 10
 .B read [<blocksize>] [ <#blocks/#bytes> ]
 read blocks from the tape, write them to stdout. If we are in variable
@@ -98,13 +98,13 @@ we currently support in variable block mode is 128K, MAX_READ_SIZE will
 need to be turned into a settable variable to allow bigger reads). If
 <blocksize> is ommitted, we assume that we're in variable block mode, and
 that we are going to read from tape until we hit a tapemark or end of
-partition or end of tape. 
+partition or end of tape.
 
 
 .SH AUTHORS
-This program was written by Eric Lee Green <eric@badtux.org>. 
+This program was written by Eric Lee Green <eric@badtux.org>.
 Major portions of the 'mtxl.c' library used herein were written by
-Leonard Zubkoff. 
+Leonard Zubkoff.
 .P
 
 The SCSI read and write routines are based upon those that Richard
@@ -119,28 +119,23 @@ identifiers). As required by 'mtxl.c', these routines are licensed
 under the GNU General Public License.
 
 .SH HINTS
-Under Linux, 
-.B cat /proc/scsi/scsi
-will tell you what SCSI devices you have.
-You can then refer to them as 
-.B /dev/sga,
-.B /dev/sgb, 
-etc. by the order they
-are reported.
+Under Linux,
+.B lsscsi \-\-generic
+will tell you what SCSI devices you have and their device names.
 .P
-Under FreeBSD, 
+Under FreeBSD,
 .B camcontrol devlist
 will tell you what SCSI devices you
-have, along with which 
+have, along with which
 .B pass
 device controls them.
 .P
 Under Solaris 7 and 8,
 .B /usr/sbin/devfsadm -C
 will clean up your /devices directory. Then
-.B find /devices -name 'st@*' -print 
+.B find /devices -name 'st@*' -print
 will return a list of all tape drives. /dev on Solaris is apparently only
-of historical interest. 
+of historical interest.
 
 .SH BUGS AND LIMITATIONS
 
@@ -149,7 +144,7 @@ for
 where  you are doing variable-block-size reads and wish for <n> bytes,
 it instead reads one and exactly one block from tape and prints that
 (no matter what its size). Use 'dd' on the output of scsitape if you
-want finer control. 
+want finer control.
 .P
 .B scsitape read 0
 attempts reads of MAX_READ_SIZE, which is currently 128K. If blocks on tape
@@ -160,19 +155,19 @@ This program does not interact well (or at all :-) with your OS's
 native tape driver.  You will likely see weird things happen if you
 attempt to intermingle scsitape commands with native tape driver
 operations. Note that BRU 16.1 for Solaris (and possibly others, but
-Solaris I know about) will have a 'scsi' keyword to bypass the 
+Solaris I know about) will have a 'scsi' keyword to bypass the
 native tape driver and write via direct uscsi commands, so if you use
 'scsitape' to bypass the flaws of the native Solaris driver, you can use
 BRU 16.1 to write your actual tape archives. (Assuming that BRU 16.1
-has been released at the time that you read this). 
+has been released at the time that you read this).
 
 .SH AVAILABILITY
-This version of 
+This version of
 .B scsitape
-is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net> 
-as part of the 'mtx' suite of programs. The 'mtx' home page is 
-http://mtx.sourceforge.net and the actual code is currently available there and via 
-SVN from http://sourceforge.net/projects/mtx. 
+is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net>
+as part of the 'mtx' suite of programs. The 'mtx' home page is
+http://mtx.sourceforge.net and the actual code is currently available there and via
+SVN from http://sourceforge.net/projects/mtx.
 
 .SH SEE ALSO
 .BR loaderinfo (1), tapeinfo (1), mtx (1)

--- a/mtx/tapeinfo.1
+++ b/mtx/tapeinfo.1
@@ -27,45 +27,48 @@ tapeinfo \- report SCSI tape device info
 .SH SYNOPSIS
 tapeinfo -f <scsi-generic-device>
 .SH DESCRIPTION
-The 
+The
 .B tapeinfo
 command reads various information from SCSI tape drives that is not
 generally available via most vendors' tape drivers. It issues raw
 commands directly to the tape drive, using either the operating system's
 SCSI generic device ( e.g. /dev/sg0 on Linux, /dev/pass0 on FreeBSD) or
-the raw SCSI I/O ioctl on a tape device on some operating systems. 
+the raw SCSI I/O ioctl on a tape device on some operating systems.
 .P
 One good time to use 'tapeinfo' is immediately after a tape i/o operation has
 failed. On tape drives that support HP's 'tapealert' API, 'tapeinfo' will
-report a more exact description of what went wrong. 
+report a more exact description of what went wrong.
 .P
 Do be aware that 'tapeinfo' is not a substitute for your operating system's
 own 'mt' or similar tape driver control program. It is intended to supplement,
 not replace, programs like 'mt' that access your operating system's tape
-driver in order to report or set information. 
+driver in order to report or set information.
 .SH OPTIONS
 The first argument, given following
 .B -f
 , is the SCSI generic device corresponding to your tape drive.
 Consult your operating system's documentation for more information (for
-example, under Linux these are generally start at /dev/sg0 
+example, under Linux these are generally start at /dev/sg0
 under FreeBSD these start at /dev/pass0).
 .P
-Under FreeBSD, 'camcontrol devlist' will tell you what SCSI devices you
-have, along with which 'pass' device controls them. Under Linux,
-"cat /proc/scsi/scsi" will tell you what SCSI devices you have.
+Under FreeBSD,
+.B camcontrol devlist
+will tell you what SCSI devices you have, along with which 'pass' device
+controls them. Under Linux, the command
+.B'lsscsi \-\-generic
+will tell you what SCSI devices you have.
 
 .SH BUGS AND LIMITATIONS
 .P
 This program has only been tested on Linux with a limited number of
-tape drives (HP DDS4, Seagate AIT). 
+tape drives (HP DDS4, Seagate AIT, IBM LTO-6).
 .P
 .SH AVAILABILITY
 .B tapeinfo
-is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net> 
-as part of the 'mtx' suite of programs. The 'mtx' home page is 
-http://mtx.sourceforge.net and the actual code is currently available there and via 
-SVN from http://sourceforge.net/projects/mtx. 
+is currently being maintained by Robert Nelson <robertnelson@users.sourceforge.net>
+as part of the 'mtx' suite of programs. The 'mtx' home page is
+http://mtx.sourceforge.net and the actual code is currently available there and via
+SVN from http://sourceforge.net/projects/mtx.
 
 .SH SEE ALSO
 .BR mt (1), mtx (1), scsitape (1), scsieject (1), loaderinfo (1)


### PR DESCRIPTION
1. Suggest "lscsi" instead of "cat /proc/scsi/scsi" for Linux, because
   the latter has been a legacy feature since about 2011.
2. Update Linux device file naming to match usual names with udev.
3. Mention some more modern tape hardware on which the tools have been tested.

These changes span a number of manpages and the FAQ.  Some parts of
the diff also remove trailing blanks from the documentation files.